### PR TITLE
fix «SyntaxError: Block-scoped declarations (let, const, function, cl…

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+'use strict';
 var cspHeader = require('csp-header');
 var crypto = require('crypto');
 var parseDomain = require('parse-domain');


### PR DESCRIPTION
…ass) not yet supported outside strict mode» for Node v4.5.0 (and presumably v5)